### PR TITLE
:white_check_mark: 使用 MockerFixture 限制测试时配置的变更范围

### DIFF
--- a/tests/post/test_generate.py
+++ b/tests/post/test_generate.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 from nonebug.app import App
+from pytest_mock import MockerFixture
 
 now = time()
 passed = now - 3 * 60 * 60
@@ -166,7 +167,7 @@ Vero hendrerit vero diam et lorem blandit ex diam ex...
 
 
 @pytest.mark.asyncio
-async def test_generate_msg(mock_platform):
+async def test_generate_msg(mock_platform, mocker: MockerFixture):
     from nonebot_plugin_saa import Text, Image
 
     from nonebot_bison.post import Post
@@ -187,7 +188,7 @@ async def test_generate_msg(mock_platform):
     res1 = await post.generate()
     assert isinstance(res1[0], Image)
 
-    plugin_config.bison_use_browser = False
+    mocker.patch.object(plugin_config, "bison_use_browser", False)
 
     res3 = await post.generate()
     assert res3[0]
@@ -196,14 +197,14 @@ async def test_generate_msg(mock_platform):
 
 @pytest.mark.asyncio
 @pytest.mark.render
-async def test_msg_segments_convert(mock_platform):
+async def test_msg_segments_convert(mock_platform, mocker: MockerFixture):
     from nonebot_plugin_saa import Image
 
     from nonebot_bison.post import Post
     from nonebot_bison.plugin_config import plugin_config
     from nonebot_bison.utils import ProcessContext, DefaultClientManager
 
-    plugin_config.bison_use_pic = True
+    mocker.patch.object(plugin_config, "bison_use_pic", True)
 
     post: Post = await mock_platform(ProcessContext(DefaultClientManager())).parse(raw_post_list_1[0])
     assert post.platform.default_theme == "basic"

--- a/tests/sub_manager/test_add.py
+++ b/tests/sub_manager/test_add.py
@@ -2,6 +2,7 @@ import respx
 import pytest
 from httpx import Response
 from nonebug.app import App
+from pytest_mock import MockerFixture
 from nonebug_saa import should_send_saa
 
 from ..platforms.utils import get_json
@@ -9,14 +10,15 @@ from ..utils import BotReply, fake_admin_user, fake_group_message_event, add_rep
 
 
 @pytest.mark.asyncio
-async def test_configurable_at_me_true_failed(app: App):
+async def test_configurable_at_me_true_failed(app: App, mocker: MockerFixture):
     from nonebot.adapters.onebot.v11.bot import Bot
     from nonebot.adapters.onebot.v11.message import Message
 
     from nonebot_bison.plugin_config import plugin_config
     from nonebot_bison.sub_manager import add_sub_matcher
 
-    plugin_config.bison_to_me = True
+    mocker.patch.object(plugin_config, "bison_to_me", True)
+
     async with app.test_matcher(add_sub_matcher) as ctx:
         bot = ctx.create_bot(base=Bot)
         event = fake_group_message_event(message=Message("添加订阅"), sender=fake_admin_user)
@@ -33,7 +35,7 @@ async def test_configurable_at_me_true_failed(app: App):
 
 
 @pytest.mark.asyncio
-async def test_configurable_at_me_false(app: App):
+async def test_configurable_at_me_false(app: App, mocker: MockerFixture):
     from nonebot.adapters.onebot.v11.bot import Bot
     from nonebot.adapters.onebot.v11.message import Message
 
@@ -41,7 +43,8 @@ async def test_configurable_at_me_false(app: App):
     from nonebot_bison.plugin_config import plugin_config
     from nonebot_bison.sub_manager import add_sub_matcher, common_platform
 
-    plugin_config.bison_to_me = False
+    mocker.patch.object(plugin_config, "bison_to_me", False)
+
     async with app.test_matcher(add_sub_matcher) as ctx:
         bot = ctx.create_bot(base=Bot)
         event = fake_group_message_event(message=Message("添加订阅"), sender=fake_admin_user)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,16 +1,17 @@
 import pytest
 from nonebug.app import App
+from pytest_mock import MockerFixture
 
 
 @pytest.mark.asyncio
 @pytest.mark.render
-async def test_render(app: App):
+async def test_render(app: App, mocker: MockerFixture):
     from nonebot_plugin_saa import Image
 
     from nonebot_bison.utils import parse_text
     from nonebot_bison.plugin_config import plugin_config
 
-    plugin_config.bison_use_pic = True
+    mocker.patch.object(plugin_config, "bison_use_pic", True)
 
     res = await parse_text(
         "a\nbbbbbbbbbbbbbbbbbbbbbb\ncd\n<h1>中文</h1>VuePress 由两部分组成：第一部分是一个极简静态网站生成器(opens new"
@@ -24,13 +25,13 @@ async def test_render(app: App):
 
 @pytest.mark.asyncio
 @pytest.mark.render
-async def test_convert(app: App):
+async def test_convert(app: App, mocker: MockerFixture):
     from nonebot_plugin_saa import Text, Image
 
     from nonebot_bison.utils import text_to_image
     from nonebot_bison.plugin_config import plugin_config
 
-    plugin_config.bison_use_pic = True
+    mocker.patch.object(plugin_config, "bison_use_pic", True)
 
     text = Text("如果，生命的脚印终有一天会被时间的尘埃掩埋......那我们就永远不能——停下脚步")
     res = await text_to_image(text)

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -61,7 +61,7 @@ async def test_send_queue(app: App, mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_send_merge_no_queue(app: App):
+async def test_send_merge_no_queue(app: App, mocker: MockerFixture):
     from nonebot.adapters.onebot.v11.bot import Bot
     from nonebot_plugin_saa.auto_select_bot import refresh_bots
     from nonebot_plugin_saa import Text, Image, TargetQQGroup, MessageFactory, AggregatedMessageFactory
@@ -69,8 +69,8 @@ async def test_send_merge_no_queue(app: App):
     from nonebot_bison.send import send_msgs
     from nonebot_bison.plugin_config import plugin_config
 
-    plugin_config.bison_use_pic_merge = 1
-    plugin_config.bison_use_queue = False
+    mocker.patch.object(plugin_config, "bison_use_pic_merge", 1)
+    mocker.patch.object(plugin_config, "bison_use_queue", False)
 
     async with app.test_api() as ctx:
         bot = ctx.create_bot(base=Bot, self_id="8888")
@@ -106,7 +106,7 @@ async def test_send_merge_no_queue(app: App):
         await send_msgs(target, message)
 
 
-async def test_send_merge2_no_queue(app: App):
+async def test_send_merge2_no_queue(app: App, mocker: MockerFixture):
     from nonebot.adapters.onebot.v11.bot import Bot
     from nonebot_plugin_saa.auto_select_bot import refresh_bots
     from nonebot_plugin_saa import Text, Image, TargetQQGroup, MessageFactory, AggregatedMessageFactory
@@ -114,8 +114,8 @@ async def test_send_merge2_no_queue(app: App):
     from nonebot_bison.send import send_msgs
     from nonebot_bison.plugin_config import plugin_config
 
-    plugin_config.bison_use_pic_merge = 2
-    plugin_config.bison_use_queue = False
+    mocker.patch.object(plugin_config, "bison_use_pic_merge", 2)
+    mocker.patch.object(plugin_config, "bison_use_queue", False)
 
     async with app.test_api() as ctx:
         bot = ctx.create_bot(base=Bot, self_id="8888")

--- a/tests/theme/test_themes.py
+++ b/tests/theme/test_themes.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from flaky import flaky
 from nonebug import App
+from pytest_mock import MockerFixture
 
 if TYPE_CHECKING:
     from nonebot_bison.post import Post
@@ -134,10 +135,10 @@ async def test_theme_need_browser(app: App, mock_post):
 
 
 @pytest.mark.asyncio
-async def test_theme_no_enable_use_browser(app: App, mock_post):
+async def test_theme_no_enable_use_browser(app: App, mock_post, mocker: MockerFixture):
     from nonebot_bison.plugin_config import plugin_config
 
-    plugin_config.bison_use_browser = False
+    mocker.patch.object(plugin_config, "bison_use_browser", False)
 
     from nonebot_bison.theme import Theme, ThemeRenderUnsupportError, theme_manager
 
@@ -155,7 +156,6 @@ async def test_theme_no_enable_use_browser(app: App, mock_post):
         await theme.do_render(mock_post)
 
     theme_manager.unregister(theme.name)
-    plugin_config.bison_use_browser = True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
把`plugin_config`的变更局限在单个测试函数里