### PR TITLE
:bug: 修复新版 httpx 中 proxy 不起效的问题

### DIFF
--- a/nonebot_bison/utils/http.py
+++ b/nonebot_bison/utils/http.py
@@ -3,7 +3,7 @@ import httpx
 from nonebot_bison.plugin_config import plugin_config
 
 http_args = {
-    "proxies": plugin_config.bison_proxy or None,
+    "proxy": plugin_config.bison_proxy or None,
 }
 http_headers = {"user-agent": plugin_config.bison_ua}
 


### PR DESCRIPTION
由于上游 httpx 移除了 proxies，同步更改 "proxies" 到 "proxy" 