### PR TITLE
修复 Docker 镜像缺少 arm64 架构

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: felinae98/nonebot-bison:${{ env.GIT_BRANCH_NAME }}
           cache-from: type=gha
@@ -202,6 +203,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile_without_browser
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: felinae98/nonebot-bison:${{ env.GIT_BRANCH_NAME }}-nobrowser
           cache-from: type=gha

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: felinae98/nonebot-bison:${{ inputs.dockerTag }}
           cache-from: type=gha
@@ -60,6 +61,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile_without_browser
+          platforms: linux/amd64,linux/arm64
           tags: felinae98/nonebot-bison:${{ inputs.dockerTag }}-nobrowser
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             felinae98/nonebot-bison:latest
@@ -101,6 +102,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile_without_browser
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             felinae98/nonebot-bison:${{ env.TAG_NAME }}-nobrowser


### PR DESCRIPTION
## Summary
- 为 release/main/manual-build 的 Docker 推送补充 `linux/amd64,linux/arm64` 多架构构建
- 生成 multi-arch manifest 以解决 ARM64 拉取失败

## Test plan
- [ ] `uv run pytest`（本地失败：tests/platforms/test_weibo.py::test_rsshub_compare；tests/test_proxy.py::test_without_proxy）


Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MountainDash/nonebot-bison/757)
<!-- Reviewable:end -->

fixed #757
